### PR TITLE
Removed Content-Type check and increased 3rd header search scope

### DIFF
--- a/magic/Magdir/msooxml
+++ b/magic/Magdir/msooxml
@@ -16,21 +16,21 @@
 0		string		PK\003\004
 !:strength +10
 # make sure the first file is correct
->0x1E		regex		\[Content_Types\]\.xml|_rels/\.rels
+#>0x1E		regex		\\[Content_Types\\]\\.xml|_rels/\\.rels
 # skip to the second local file header
 # since some documents include a 520-byte extra field following the file
 # header, we need to scan for the next header
->>(18.l+49)	search/2000	PK\003\004
+>(18.l+49)	search/2000	PK\003\004
 # now skip to the *third* local file header; again, we need to scan due to a
 # 520-byte extra field following the file header
->>>&26		search/1000	PK\003\004
+>>&26		search/2000	PK\003\004
 # and check the subdirectory name to determine which type of OOXML
 # file we have.  Correct the mimetype with the registered ones:
 # http://technet.microsoft.com/en-us/library/cc179224.aspx
->>>>&26		string		word/		Microsoft Word 2007+
+>>>&26		string		word/		Microsoft Word 2007+
 !:mime application/vnd.openxmlformats-officedocument.wordprocessingml.document
->>>>&26		string		ppt/		Microsoft PowerPoint 2007+
+>>>&26		string		ppt/		Microsoft PowerPoint 2007+
 !:mime application/vnd.openxmlformats-officedocument.presentationml.presentation
->>>>&26		string		xl/		Microsoft Excel 2007+
+>>>&26		string		xl/		Microsoft Excel 2007+
 !:mime application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
->>>>&26		default		x		Microsoft OOXML
+>>>&26		default		x		Microsoft OOXML


### PR DESCRIPTION
  Removed Content-Type check (as indicated by author it is known not to be there
    in open/libreoffice created docs) and increased the search scope for the
    third file header as with some MS Office created and then
    LibreOffice modified files the check failed otherwise.

