### PR TITLE
Fixed bug in get_default_magic

### DIFF
--- a/src/magic.c
+++ b/src/magic.c
@@ -185,7 +185,7 @@ out:
 			if (asprintf(&tmppath,
 			    "%s/share/misc/magic.mgc", dllpath) >= 0)
 				APPENDPATH();
-			else if (asprintf(&tmppath,
+			if (asprintf(&tmppath,
 			    "%s/magic.mgc", dllpath) >= 0)
 				APPENDPATH();
 		}


### PR DESCRIPTION
On Windows the function did not look for magic.mgc in the executable directory.
This was caused by a extra "else" that caused <dllpath>/magic.mgc test to be skipped, unless the previous call to asprintf failed.